### PR TITLE
Enable aws_backup_plan to be found by name

### DIFF
--- a/internal/service/backup/find.go
+++ b/internal/service/backup/find.go
@@ -110,3 +110,38 @@ func FindVaultByName(ctx context.Context, conn *backup.Backup, name string) (*ba
 
 	return output, nil
 }
+
+func FindPlanByName(ctx context.Context, conn *backup.Backup, name string) (*backup.GetBackupPlanOutput, error) {
+	plans, err := conn.ListBackupPlans(&backup.ListBackupPlansInput{})
+	if err != nil {
+		return nil, err
+	}
+
+	output := &backup.GetBackupPlanOutput{}
+
+	for _, output := range plans.BackupPlansList {
+		if *output.BackupPlanName == name {
+			return conn.GetBackupPlan(&backup.GetBackupPlanInput{
+				BackupPlanId: output.BackupPlanId,
+				VersionId:    output.VersionId,
+			})
+		}
+	}
+
+	if tfawserr.ErrCodeEquals(err, backup.ErrCodeResourceNotFoundException, errCodeAccessDeniedException) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: name,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, tfresource.NewEmptyResultError(name)
+	}
+
+	return output, nil
+}

--- a/internal/service/backup/plan_data_source.go
+++ b/internal/service/backup/plan_data_source.go
@@ -20,7 +20,8 @@ func DataSourcePlan() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"plan_id": {
 				Type:     schema.TypeString,
-				Required: true,
+				Computed: true,
+				Optional: true,
 			},
 			"arn": {
 				Type:     schema.TypeString,
@@ -29,6 +30,7 @@ func DataSourcePlan() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Computed: true,
+				Optional: true,
 			},
 			"tags": tftags.TagsSchemaComputed(),
 			"version": {
@@ -44,26 +46,49 @@ func dataSourcePlanRead(ctx context.Context, d *schema.ResourceData, meta interf
 	conn := meta.(*conns.AWSClient).BackupConn(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	id := d.Get("plan_id").(string)
+	if v, ok := d.GetOk("plan_id"); ok {
+		resp, err := conn.GetBackupPlanWithContext(ctx, &backup.GetBackupPlanInput{
+			BackupPlanId: aws.String(v.(string)),
+		})
 
-	resp, err := conn.GetBackupPlanWithContext(ctx, &backup.GetBackupPlanInput{
-		BackupPlanId: aws.String(id),
-	})
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "getting Backup Plan: %s", err)
-	}
+		d.SetId(aws.StringValue(resp.BackupPlanId))
+		d.Set("arn", resp.BackupPlanArn)
+		d.Set("name", resp.BackupPlan.BackupPlanName)
+		d.Set("version", resp.VersionId)
 
-	d.SetId(aws.StringValue(resp.BackupPlanId))
-	d.Set("arn", resp.BackupPlanArn)
-	d.Set("name", resp.BackupPlan.BackupPlanName)
-	d.Set("version", resp.VersionId)
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "getting Backup Plan: %s", err)
+		}
 
-	tags, err := listTags(ctx, conn, aws.StringValue(resp.BackupPlanArn))
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for Backup Plan (%s): %s", id, err)
-	}
-	if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
+		tags, err := listTags(ctx, conn, aws.StringValue(resp.BackupPlanArn))
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "listing tags for Backup Plan (%s): %s", v, err)
+		}
+		if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
+		}
+	} else if v, ok := d.GetOk("name"); ok {
+		resp, err := FindPlanByName(ctx, conn, v.(string))
+
+		d.SetId(aws.StringValue(resp.BackupPlanId))
+		d.Set("arn", resp.BackupPlanArn)
+		d.Set("name", resp.BackupPlan.BackupPlanName)
+		d.Set("version", resp.VersionId)
+		d.Set("plan_id", aws.StringValue(resp.BackupPlanId))
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "Getting Backup Plan: %s", err)
+		}
+
+		tags, err := listTags(ctx, conn, aws.StringValue(resp.BackupPlanArn))
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "listing tags for Backup Plan (%s): %s", v, err)
+		}
+		if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
+		}
+	} else {
+		return sdkdiag.AppendErrorf(diags, "plan_id or name must be set")
 	}
 
 	return diags

--- a/internal/service/backup/plan_data_source_test.go
+++ b/internal/service/backup/plan_data_source_test.go
@@ -30,6 +30,15 @@ func TestAccBackupPlanDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(datasourceName, "tags.%", resourceName, "tags.%"),
 				),
 			},
+			{
+				Config: testAccPlanDataSourceConfig_name(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(datasourceName, "version", resourceName, "version"),
+					resource.TestCheckResourceAttrPair(datasourceName, "tags.%", resourceName, "tags.%"),
+				),
+			},
 		},
 	})
 }
@@ -58,6 +67,34 @@ resource "aws_backup_plan" "test" {
 
 data "aws_backup_plan" "test" {
   plan_id = aws_backup_plan.test.id
+}
+`, rInt)
+}
+
+func testAccPlanDataSourceConfig_name(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_backup_vault" "test" {
+    name = "tf_acc_test_backup_vault_%[1]d"
+}
+
+resource "aws_backup_plan" "test" {
+    name = "tf_acc_test_backup_plan_%[1]d"
+
+    rule {
+        rule_name         = "tf_acc_test_backup_rule_%[1]d"
+        target_vault_name = aws_backup_vault.test.name
+        schedule          = "cron(0 12 * * ? *)"
+    }
+
+    tags = {
+        Name = "Value%[1]d"
+        Key2 = "Value2b"
+        Key3 = "Value3"
+    }
+}
+
+data "aws_backup_plan" "test" {
+    name = aws_backup_plan.test.name
 }
 `, rInt)
 }

--- a/website/docs/d/backup_plan.html.markdown
+++ b/website/docs/d/backup_plan.html.markdown
@@ -22,7 +22,8 @@ data "aws_backup_plan" "example" {
 
 The following arguments are supported:
 
-* `plan_id` - (Required) Backup plan ID.
+* `plan_id` - (Optional) Backup plan ID.
+* `name` - (Optional) Backup plan name.
 
 ## Attributes Reference
 


### PR DESCRIPTION
### Description
This enables the user to find existing backup plans through name instead of just plan_id. This allows this data lookup to be used in scenarios where backup vaults and plans are created independently from the resources being backed up, enabling users to assign resources to an existing plan.

### Output from Acceptance Testing
```
$ make testacc TESTS=TestAccBackupPlanDataSource_basic PKG=backup

...
```
